### PR TITLE
refactor: use git config for username storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,3 @@ Thumbs.db
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
-# User-specific config
-agent-skills/.username

--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ yarn install
 yarn set-username
 ```
 
-The `set-username` script saves your username to `agent-skills/.username` (gitignored). Skills that need a username will read from this file at runtime.
+The `set-username` script saves your username to `git config --global skill.username`. Skills that need a username will read from this config at runtime.
 
 ## Available Commands
 
-| Command              | Description                              |
-| -------------------- | ---------------------------------------- |
-| `yarn set-username`  | Save your username for use in skills     |
-| `yarn skills:add`    | Install skills to Claude Code            |
-| `yarn skills:list`   | List available skills                    |
+| Command             | Description                          |
+| ------------------- | ------------------------------------ |
+| `yarn set-username` | Save your username for use in skills |
+| `yarn skills:add`   | Install skills to Claude Code        |
+| `yarn skills:list`  | List available skills                |
 
 > **Tip:** When using `yarn skills:add`, it is recommended to choose the symlink option when prompted. This maintains a single source of truth, so any changes to skills in this repository are immediately reflected in Claude Code.
 

--- a/agent-skills/skills/commit-push-branch/SKILL.md
+++ b/agent-skills/skills/commit-push-branch/SKILL.md
@@ -7,9 +7,10 @@ model: sonnet
 # Git New Branch Workflow
 
 1. Checkout main and pull latest
-2. Create branch following template
-3. Stage all, commit following template, never add Co-Authored-By. Commit message should be very short, max 50 characters
-4. Push branch
+2. Read the username by running: `git config skill.username`
+3. Create branch following template
+4. Stage all, commit following template, never add Co-Authored-By. Commit message should be very short, max 50 characters
+5. Push branch
 
 ### Rules
 
@@ -18,8 +19,6 @@ model: sonnet
 - Never add signatures or Co-Authored-By
 
 ## Branch name template
-
-Read the username by running: `cat agent-skills/.username`
 
 `<type>/<username>/<short-kebab-case-description>`
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Agent Skills Framework for Claude Code",
   "license": "Apache-2.0",
   "devDependencies": {
-    "skills": "1.3.4"
+    "skills": "1.3.8"
   },
   "scripts": {
     "skills:add": "skills add ./agent-skills/skills",

--- a/scripts/set-username.sh
+++ b/scripts/set-username.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Resolve the absolute path to the agent-skills directory
-SKILLS_DIR="$(cd "$(dirname "$0")/../agent-skills" && pwd)"
-
 # Prompt for the username
 read -rp "Enter your username: " username
 
@@ -12,7 +9,7 @@ if [[ -z "$username" ]]; then
   exit 1
 fi
 
-# Write the username to a gitignored file
-printf '%s' "$username" > "$SKILLS_DIR/.username"
+# Store the username in git config
+git config --global skill.username "$username"
 
-echo "Username '$username' saved to agent-skills/.username"
+echo "Username '$username' saved to git config (skill.username)"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,16 +9,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fellesdatakatalog/fdk-labs@workspace:."
   dependencies:
-    skills: "npm:1.3.4"
+    skills: "npm:1.3.8"
   languageName: unknown
   linkType: soft
 
-"skills@npm:1.3.4":
-  version: 1.3.4
-  resolution: "skills@npm:1.3.4"
+"skills@npm:1.3.8":
+  version: 1.3.8
+  resolution: "skills@npm:1.3.8"
   bin:
     add-skill: bin/cli.mjs
     skills: bin/cli.mjs
-  checksum: 10c0/57a9819c2a6eccbbaab92270d28b932304005a5e651494b176d4448405ed7cd1a73c0c73afef8031daa1560535b6cb608bfbda8b942e66668174cde37ba64493
+  checksum: 10c0/cf23f801b6c635932e214536d5329d7d169572c760d70f02c4a95d7e8a794b352375547d6c2e3e00164bdb335ec690bd1b985c4f1101c1339c2b556e1ce5b7db
   languageName: node
   linkType: hard


### PR DESCRIPTION
# Summary 

- Replace file-based username storage with `git config skill.username`
- Update `set-username.sh` to use git config instead of `.username` file
- Update skill documentation to read username from git config
- Remove `.username` from `.gitignore`
- Bump `skills` package from 1.3.4 to 1.3.8