### PR TITLE
feat: add create-branch-and-pr skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ Invoke skills using `/skill-name`:
 | `/commit-push`             | Stage, commit, and push to current branch       |
 | `/commit-push-branch`      | Pull main, create branch, commit, and push      |
 | `/create-pr`               | Generate PR description (arg: `fixes "#123"`)   |
+| `/create-branch-and-pr`    | Branch, commit, push, and create pull request   |
 | `/security-check-frontend` | Run npm audit and check Dependabot alerts       |
 | `/improve-prompt`          | Analyze and improve a prompt (arg: prompt text) |
 | `/create-feature-issue`    | Create GitHub feature issue (Norwegian)         |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ Invoke skills using `/skill-name`:
 | `/commit-push`             | Stage, commit, and push to current branch       |
 | `/commit-push-branch`      | Pull main, create branch, commit, and push      |
 | `/create-pr`               | Generate pull request description and title     |
+| `/create-branch-and-pr`    | Branch, commit, push, and create pull request   |
 | `/security-check-frontend` | Run npm audit and check Dependabot alerts       |
 | `/improve-prompt`          | Analyze and improve a prompt (arg: prompt text) |
 | `/create-feature-issue`    | Create GitHub feature issue (Norwegian)         |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of agent resources for AI-assisted development workflows.
 
 | Resource                                 | Description                       |
 | ---------------------------------------- | --------------------------------- |
-| [agent-skills](./agent-skills/README.md) | Skill definitions for Claude Code |
+| [agent-skills](./agent-skills/README.md) | Skill definitions for AI agents |
 
 ## Requirements
 
@@ -27,10 +27,10 @@ The `set-username` script saves your username to `git config --global skill.user
 | Command             | Description                          |
 | ------------------- | ------------------------------------ |
 | `yarn set-username` | Save your username for use in skills |
-| `yarn skills:add`   | Install skills to Claude Code        |
+| `yarn skills:add`   | Install skills to your agent         |
 | `yarn skills:list`  | List available skills                |
 
-> **Tip:** When using `yarn skills:add`, it is recommended to choose the symlink option when prompted. This maintains a single source of truth, so any changes to skills in this repository are immediately reflected in Claude Code.
+> **Tip:** When using `yarn skills:add`, it is recommended to choose the symlink option when prompted. This maintains a single source of truth, so any changes to skills in this repository are immediately reflected in your agent.
 
 ## License
 

--- a/agent-skills/README.md
+++ b/agent-skills/README.md
@@ -9,6 +9,7 @@ Agent Skills Framework for Claude Code. This repository contains skill definitio
 | `/commit-push`          | Stage, commit, and push to current branch   |
 | `/commit-push-branch`   | Pull main, create branch, commit, and push  |
 | `/create-pr`            | Generate pull request description and title |
+| `/create-branch-and-pr` | Branch, commit, push, and create pull request |
 | `/security-check-frontend` | Run npm audit and check Dependabot alerts |
 | `/improve-prompt`       | Analyze and improve a prompt                |
 | `/create-feature-issue` | Create GitHub feature issue                 |

--- a/agent-skills/README.md
+++ b/agent-skills/README.md
@@ -1,6 +1,6 @@
 # Agent Skills
 
-Agent Skills Framework for Claude Code. This repository contains skill definitions that extend Claude Code with reusable workflows for common development tasks.
+Agent Skills Framework for AI-assisted development. This repository contains skill definitions that extend your agent with reusable workflows for common development tasks.
 
 ## Available Skills
 

--- a/agent-skills/skills/create-branch-and-pr/SKILL.md
+++ b/agent-skills/skills/create-branch-and-pr/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: create-branch-and-pr
+description: Creates a new branch, commits changes, pushes, and opens a pull request. Use when the user says 'branch and PR', 'new branch with PR', or 'feature branch and pull request'.
+model: sonnet
+argument-hint: "[fixes #issue-number]"
+---
+
+# Git Branch and Pull Request Workflow
+
+1. Checkout main and pull latest
+2. Read the username by running: `git config skill.username`. If not found, ask user to run `scripts/set-username.sh` in fdk-labs to set it first
+3. Create branch following the branch name template
+4. Stage all, commit following the commit message template. Commit message should be very short, max 50 characters
+5. Push branch
+6. Write a short pull request title and description, then ask for confirmation before creating the PR
+
+### Rules
+
+- Generate messages based on the current diff
+- Never commit or push directly to main
+- Never add signatures or Co-Authored-By
+- Keep PR text short
+- Use bullet points for changes in the PR description
+- Never include a test plan
+- Always ask for confirmation before creating the PR in GitHub
+- Do not create the PR until the user explicitly confirms
+- Produce the PR description in the exact format below
+
+## Branch name template
+
+`<type>/<username>/<short-kebab-case-description>`
+
+## Commit message template
+
+`<type>: <description>`
+
+## PR title
+
+`<type>: <description>`
+
+Types: feat, fix, docs, style, refactor, test, chore
+
+### PR description output format (exact)
+
+```text
+# Summary $ARGUMENTS
+
+- ...
+- ...
+```

--- a/agent-skills/skills/create-pr/SKILL.md
+++ b/agent-skills/skills/create-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: create-pr
 description: Creates a pull request with auto-generated title and description. Use when the user says 'create PR', 'open pull request', or 'submit for review'.
 model: sonnet
-argument-hint: [fixes #issue-number]
+argument-hint: "[fixes #issue-number]"
 ---
 
 Write a short pull request description and title for GitHub, then ask for confirmation before creating the PR.


### PR DESCRIPTION
# Summary fixes #4

- Add new `/create-branch-and-pr` skill combining branch, commit, push, and PR creation
- Fix YAML parse error in `create-pr` skill (`argument-hint` with `#` now quoted)
- Update CLAUDE.md, AGENTS.md, and agent-skills/README.md with new skill