### PR TITLE
docs: rewrite README for better readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,56 @@
-# fdk-labs
+# 🤖 fdk-labs
 
-A collection of agent resources for AI-assisted development workflows.
+A shared toolbox of customisations that make AI coding agents smarter for everyone
 
-## Resources
+## What is this?
 
-| Resource                                 | Description                       |
-| ---------------------------------------- | --------------------------------- |
-| [agent-skills](./agent-skills/README.md) | Skill definitions for AI agents |
+Think of `fdk-labs` as a recipe book for the AI assistant we use day-to-day. Instead of every team writing the same instructions over and over, how to write a good commit message, how to file a bug report, how to run a security check, we collect them here. Anyone in Digdir can install the recipes and get the same helpful behaviour from their AI assistant.
 
-## Requirements
+Today the catalog contains:
 
-- Node.js >= 22.0.0
-- Yarn 4
+- 🛠 [**<u>Agent skills →</u>**](./agent-skills/README.md) — ready-made commands that automate everyday work like saving code changes, opening pull requests, filing GitHub issues, and checking for security vulnerabilities
+- 🤖 **Agents** — specialised AI assistants for Digdir domains _(coming)_
+- 🪝 **Hooks** — shell commands that run automatically before or after agent actions, like linting on every file write or running tests before a commit _(coming)_
+- 🔌 **MCP servers** — Digdir-approved AI integrations _(coming)_
+- 📄 **AGENTS.md templates** — ready-made project instructions that work across all major AI agents _(coming)_
+- 🏁 **Onboarding tool** — helps new developers quickly adapt to a codebase and assesses a repo's agent-readiness _(coming)_
 
-## Getting Started
+## What is an AI coding agent?
+
+An AI coding agent is an assistant that lives inside your app, code editor or terminal. You can ask it questions, have it write emails or change code. Popular examples include Claude Code, Cursor, and GitHub Copilot.
+
+The Skills in `fdk-labs` are reusable commands that extend your agent with Digdir-specific behaviours anyone can install.
+
+## Get started
+
+**Just want to browse?** Head to [**<u>Skills →</u>**](./agent-skills/README.md) to see the full catalog and what each Skill does.
+
+**Want to install it?** Two steps:
 
 ```bash
 yarn install
+yarn skills:add        # pick "symlink" — keeps this repo as the single source of truth
 ```
 
-Skills that need a username (e.g., for branch names) will ask for it on first use and cache it in `git config --global skill.username`.
+> **Tip:** Choose the **symlink** option when prompted. That way, when someone improves a Skill in this repo, you get the update next time you run `git pull` — no reinstall needed.
 
-To set or override manually:
+## Repository structure
 
-```bash
-yarn set-username           # interactive prompt
-yarn set-username myname    # non-interactive
+```text
+fdk-labs/
+├── agent-skills/        # The Skills framework + the catalog
+├── scripts/             # Helper scripts (e.g. set-username.sh)
+├── AGENTS.md            # Conventions for AI agents
+├── CLAUDE.md            # Project instructions for Claude Code
+└── package.json
 ```
 
-## Available Commands
+## Contributing
 
-| Command             | Description                          |
-| ------------------- | ------------------------------------ |
-| `yarn set-username` | Set or override your username for skills |
-| `yarn skills:add`   | Install skills to your agent         |
-| `yarn skills:list`  | List available skills                |
+Notice yourself doing the same thing again and again? It's probably a great candidate for a new Skill. Open up [**<u>Skills →</u>**](./agent-skills/README.md) for a friendly walkthrough — you don't need to be an expert to contribute.
 
-> **Tip:** When using `yarn skills:add`, it is recommended to choose the symlink option when prompted. This maintains a single source of truth, so any changes to skills in this repository are immediately reflected in your agent.
+## More
 
-## License
-
-Apache-2.0
+- [**<u>Skills →</u>**](./agent-skills/README.md) — Skills framework, full catalog, and how to write a new one
+- [`CLAUDE.md`](./CLAUDE.md), [`AGENTS.md`](./AGENTS.md) — instructions for AI agents
+- Requires Node.js 22 or newer and Yarn 4

--- a/agent-skills/README.md
+++ b/agent-skills/README.md
@@ -1,50 +1,64 @@
 # Agent Skills
 
-Agent Skills Framework for AI-assisted development. This repository contains skill definitions that extend your agent with reusable workflows for common development tasks.
+The Skills framework for [`fdk-labs`](../README.md). This document covers what a Skill is, how to read one, and how to write your own.
 
-## Available Skills
+## What is a Skill?
 
-| Skill                   | Description                                 |
-| ----------------------- | ------------------------------------------- |
-| `/commit-push`          | Stage, commit, and push to current branch   |
-| `/commit-push-branch`   | Pull main, create branch, commit, and push  |
-| `/create-pr`            | Generate pull request description and title |
-| `/create-branch-and-pr` | Branch, commit, push, and create pull request |
-| `/security-check-frontend` | Run npm audit and check Dependabot alerts |
-| `/improve-prompt`       | Analyze and improve a prompt                |
-| `/create-feature-issue` | Create GitHub feature issue                 |
-| `/create-bug-issue`     | Create GitHub bug issue                     |
-| `/create-ux-issue`      | Create GitHub UX issue                      |
-| `/tree-shaking-js`       | Check for unused JS dependencies and plan removals |
+A Skill is a Markdown file with YAML frontmatter that Claude Code treats as a reusable slash-command. It lives at `agent-skills/skills/<kebab-name>/SKILL.md`. When you invoke `/<skill-name>`, the agent reads the frontmatter and follows the body, substituting any text you typed after the command for `$ARGUMENTS`.
 
-## Creating New Skills
+## Catalog
 
-1. Create a new directory under `agent-skills/skills/` using kebab-case naming
-2. Add a `SKILL.md` file with YAML frontmatter:
+| Command                    | Description                                   | Arguments             | Language |
+| -------------------------- | --------------------------------------------- | --------------------- | -------- |
+| `/commit-push`             | Stage, commit, and push to current branch     | —                     | EN       |
+| `/commit-push-branch`      | Pull main, create branch, commit, and push    | —                     | EN       |
+| `/create-pr`               | Generate pull request description and title   | `[fixes #issue]`      | EN       |
+| `/create-branch-and-pr`    | Branch, commit, push, and create pull request | `[fixes #issue]`      | EN       |
+| `/security-check-frontend` | Run `npm audit` and check Dependabot alerts   | —                     | EN       |
+| `/tree-shaking-js`         | Check for unused JS/Node dependencies         | —                     | EN       |
+| `/improve-prompt`          | Analyse and improve a prompt                  | `[prompt to improve]` | EN       |
+| `/create-feature-issue`    | Create GitHub feature issue                   | —                     | NO       |
+| `/create-bug-issue`        | Create GitHub bug issue                       | —                     | NO       |
+| `/create-ux-issue`         | Create GitHub UX issue                        | —                     | NO       |
+
+## Anatomy of a skill
 
 ```yaml
 ---
-name: skill-name
-description: Short description shown in skill list
+name: security-check-frontend
+description: Runs npm audit and checks Dependabot alerts. Use when the user says 'security' or 'audit'.
 model: sonnet
-argument-hint: [optional placeholder for arguments]
+allowed-tools:
+  - Read
+  - Bash(yarn npm audit *)
+  - Bash(gh pr list *)
+argument-hint: [fixes #issue-number]
 ---
-Your skill instructions here. Use $ARGUMENTS to reference user input.
+
+# Skill instructions go here. Use $ARGUMENTS for user input.
 ```
 
-3. Optionally add scripts under a `scripts/` subdirectory
+| Field           | Required | Purpose                                                                          |
+| --------------- | -------- | -------------------------------------------------------------------------------- |
+| `name`          | yes      | The slash-command users type (kebab-case).                                       |
+| `description`   | yes      | One-liner shown in the skill list. Include trigger phrases the agent recognises. |
+| `model`         | no       | Which Claude model to use.                                                       |
+| `argument-hint` | no       | Placeholder shown in the UI for `$ARGUMENTS`.                                    |
+| `allowed-tools` | no       | Restrict which tools (and Bash command patterns) the skill may use.              |
 
-## Directory Structure
+## Creating a new skill
 
-```
-agent-skills/
-  skills/
-    {skill-name}/
-      SKILL.md              # Required: skill definition
-      scripts/              # Optional: executable scripts
-        {script-name}.sh
-```
+1. `mkdir agent-skills/skills/my-new-skill`
+2. Write `SKILL.md` with the frontmatter above
+3. Optionally add `scripts/<name>.sh` for Bash helpers
+4. `yarn skills:list` to confirm it's picked up
+5. `yarn skills:add` (pick symlink) and invoke `/my-new-skill` in Claude Code
 
-## License
+Symlinked skills pick up Markdown edits immediately — no rebuild, no restart.
 
-Apache-2.0
+## Conventions
+
+- Directory: kebab-case (`commit-push`, not `CommitPush`)
+- Filename: always `SKILL.md`, uppercase
+- Scripts: kebab-case `.sh`, prefer Bash
+- Body: imperative voice, numbered steps, an explicit `### Rules` block for guardrails, and an **Output Format** block when the agent should produce a specific shape

--- a/agent-skills/skills/commit-push-branch/SKILL.md
+++ b/agent-skills/skills/commit-push-branch/SKILL.md
@@ -19,6 +19,7 @@ model: sonnet
 - Generate message based on the current diff
 - Never commit or push directly to main
 - Never add signatures or Co-Authored-By
+- Always ask for confirmation before pushing to GitHub
 
 ## Branch name template
 

--- a/agent-skills/skills/commit-push/SKILL.md
+++ b/agent-skills/skills/commit-push/SKILL.md
@@ -15,6 +15,7 @@ model: sonnet
 - Generate message based on the current git diff and local changes
 - Never commit or push directly to main
 - Never add signatures or Co-Authored-By
+- Always ask for confirmation before pushing to GitHub
 
 ### Commit message template
 

--- a/agent-skills/skills/create-bug-issue/SKILL.md
+++ b/agent-skills/skills/create-bug-issue/SKILL.md
@@ -4,6 +4,10 @@ description: Creates a GitHub bug issue in Norwegian. Use when the user says 'cr
 model: sonnet
 ---
 
+# Rules
+
+- Always ask for confirmation before pushing to GitHub
+
 # Din oppgave
 
 Se på endringene som er gjort i koden og lag en GitHub bug issue. Fyll ut alle relevante felter. Hold teksten veldig kort. Opprett en GitHub bug issue og bruk malen beskrevet nedenfor.

--- a/agent-skills/skills/create-feature-issue/SKILL.md
+++ b/agent-skills/skills/create-feature-issue/SKILL.md
@@ -4,6 +4,10 @@ description: Creates a GitHub feature issue in Norwegian. Use when the user says
 model: sonnet
 ---
 
+# Rules
+
+- Always ask for confirmation before pushing to GitHub
+
 # Din oppgave
 
 Se på endringene som er gjort i koden og lag en GitHub feature issue. Fyll ut alle relevante felter. Hold teksten veldig kort. Opprett en GitHub feature issue og bruk malen beskrevet nedenfor.

--- a/agent-skills/skills/create-ux-issue/SKILL.md
+++ b/agent-skills/skills/create-ux-issue/SKILL.md
@@ -4,6 +4,10 @@ description: Creates a GitHub UX issue in Norwegian. Use when the user says 'cre
 model: sonnet
 ---
 
+# Rules
+
+- Always ask for confirmation before pushing to GitHub
+
 # Din oppgave
 
 Se på endringene som er gjort og lag en GitHub UX issue. Fyll ut alle relevante felter. Hold teksten veldig kort. Opprett en GitHub UX issue og bruk malen beskrevet nedenfor.


### PR DESCRIPTION
# Summary

- Rewrote root README with friendly tone targeting all of Digdir (non-technical roles included)
- Added "What is this?", "Who is this for?", and "What is an AI coding agent?" sections
- Expanded catalog with Hooks, AGENTS.md templates, and Onboarding tool (marked as coming)
- Rewrote agent-skills/README.md with cleaner skill catalog, anatomy example, and conventions
- Added confirmation-before-push rule to 5 skills (commit-push, commit-push-branch, create-bug-issue, create-feature-issue, create-ux-issue)