### PR TITLE
feat: add list-issues skill and improve existing skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ Invoke skills using `/skill-name`:
 | `/create-bug-issue`        | Create GitHub bug issue (Norwegian)                |
 | `/create-ux-issue`         | Create GitHub UX issue (Norwegian)                 |
 | `/tree-shaking-js`         | Check for unused JS dependencies and plan removals |
+| `/list-issues`             | List GitHub issues assigned to me (arg: filter, e.g. "current sprint") |
 
 ## Skill File Format
 

--- a/agent-skills/skills/create-branch-and-pr/SKILL.md
+++ b/agent-skills/skills/create-branch-and-pr/SKILL.md
@@ -26,6 +26,7 @@ argument-hint: "[fixes #issue-number]"
 - Never include a test plan
 - Always ask for confirmation before creating the PR in GitHub
 - Do not create the PR until the user explicitly confirms
+- Use `gh pr create` to create the PR
 - Produce the PR description in the exact format below
 
 ## Branch name template

--- a/agent-skills/skills/create-bug-issue/SKILL.md
+++ b/agent-skills/skills/create-bug-issue/SKILL.md
@@ -2,6 +2,7 @@
 name: create-bug-issue
 description: Creates a GitHub bug issue in Norwegian. Use when the user says 'create bug issue', 'report bug', 'feil', or 'bug rapport'.
 model: sonnet
+argument-hint: "[additional context (optional)]"
 ---
 
 # Rules
@@ -10,7 +11,11 @@ model: sonnet
 
 # Din oppgave
 
-Se på endringene som er gjort i koden og lag en GitHub bug issue. Fyll ut alle relevante felter. Hold teksten veldig kort. Opprett en GitHub bug issue og bruk malen beskrevet nedenfor.
+**Additional context:** $ARGUMENTS
+
+If "Additional context" above is empty, look at the changes made in the code as before. If context is provided, use it as the primary information source for the issue and ignore code changes unless the context refers to them.
+
+Create a GitHub bug issue using `gh issue create`. Fill out all relevant fields. Keep the text very short. Use the template described below.
 
 ## 🐛 Bug-rapport
 

--- a/agent-skills/skills/create-feature-issue/SKILL.md
+++ b/agent-skills/skills/create-feature-issue/SKILL.md
@@ -2,6 +2,7 @@
 name: create-feature-issue
 description: Creates a GitHub feature issue in Norwegian. Use when the user says 'create feature issue', 'feature request', or 'ny feature'.
 model: sonnet
+argument-hint: "[additional context (optional)]"
 ---
 
 # Rules
@@ -10,7 +11,11 @@ model: sonnet
 
 # Din oppgave
 
-Se på endringene som er gjort i koden og lag en GitHub feature issue. Fyll ut alle relevante felter. Hold teksten veldig kort. Opprett en GitHub feature issue og bruk malen beskrevet nedenfor.
+**Additional context:** $ARGUMENTS
+
+If "Additional context" above is empty, look at the changes made in the code as before. If context is provided, use it as the primary information source for the issue and ignore code changes unless the context refers to them.
+
+Create a GitHub feature issue using `gh issue create`. Fill out all relevant fields. Keep the text very short. Use the template described below.
 
 # GitHub Issue
 

--- a/agent-skills/skills/create-pr/SKILL.md
+++ b/agent-skills/skills/create-pr/SKILL.md
@@ -15,6 +15,7 @@ Write a short pull request description and title for GitHub, then ask for confir
 - Always ask for confirmation before creating the PR in GitHub
 - Never add signatures or Co-Authored-By
 - Do not create the PR until the user explicitly confirms.
+- Use `gh pr create` to create the PR.
 - Produce the PR description in the exact format below.
 
 ## PR title

--- a/agent-skills/skills/create-ux-issue/SKILL.md
+++ b/agent-skills/skills/create-ux-issue/SKILL.md
@@ -2,6 +2,7 @@
 name: create-ux-issue
 description: Creates a GitHub UX issue in Norwegian. Use when the user says 'create UX issue', 'UX problem', or 'brukeropplevelse'.
 model: sonnet
+argument-hint: "[additional context (optional)]"
 ---
 
 # Rules
@@ -10,7 +11,11 @@ model: sonnet
 
 # Din oppgave
 
-Se på endringene som er gjort og lag en GitHub UX issue. Fyll ut alle relevante felter. Hold teksten veldig kort. Opprett en GitHub UX issue og bruk malen beskrevet nedenfor.
+**Additional context:** $ARGUMENTS
+
+If "Additional context" above is empty, look at the changes made in the code as before. If context is provided, use it as the primary information source for the issue and ignore code changes unless the context refers to them.
+
+Create a GitHub UX issue using `gh issue create`. Fill out all relevant fields. Keep the text very short. Use the template described below.
 
 # GitHub Issue
 

--- a/agent-skills/skills/list-issues/SKILL.md
+++ b/agent-skills/skills/list-issues/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: list-issues
+description: Lists GitHub issues assigned to the current user from project informasjonsforvaltning/9, rendered as a Markdown table. Use when the user says "list my issues", "my issues", "issues assigned to me", "current sprint issues", or "previous sprint issues".
+model: sonnet
+argument-hint: [natural language filter, e.g. "current sprint" or "include done"]
+allowed-tools: Bash(gh project item-list:*), Bash(gh project field-list:*), Bash(gh api user:*), Bash(date:*), Bash(jq:*)
+---
+
+# List Issues
+
+List GitHub issues assigned to the current user from the project board, rendered as a Markdown table. Filter via `$ARGUMENTS` using natural language: "current sprint", "previous sprint", "include done", "in review only", etc.
+
+> **Scope**: hardcoded to org `informasjonsforvaltning`, project `9`. Edit this file to point at a different board.
+
+## Steps
+
+### 1. Get the current user
+
+```bash
+gh api user --jq .login
+```
+
+Save as `$ME`. If `gh` is not authenticated or returns an error, surface stderr verbatim and stop.
+
+### 2. Resolve sprint (only if `$ARGUMENTS` mentions sprint or iteration)
+
+```bash
+gh project field-list 9 --owner informasjonsforvaltning --format json --limit 50
+```
+
+The Sprint field has shape:
+
+```json
+{
+  "name": "Sprint",
+  "type": "ProjectV2IterationField",
+  "configuration": {
+    "iterations":          [{ "title": "Sprint 43", "startDate": "2026-05-04", "duration": 14 }],
+    "completedIterations": [{ "title": "Sprint 42", "startDate": "2026-04-20", "duration": 14 }]
+  }
+}
+```
+
+- **Current** = entry in `iterations` where `startDate <= today < startDate + duration days` (today via `date -u +%Y-%m-%d`).
+- **Previous** = last entry of `completedIterations` (sorted by `startDate` desc).
+- If no current iteration matches (sprint gap), report "No active sprint on `<today>`" and stop unless `$ARGUMENTS` asked for previous.
+
+### 3. Fetch project items
+
+```bash
+gh project item-list 9 --owner informasjonsforvaltning --format json --limit 200
+```
+
+Custom fields are flattened with lowercase, no-space keys: `status` (string), `sprint` (object with `title`, `startDate`, `duration`). Unset fields are omitted from the item.
+
+If `totalCount` exceeds `--limit`, warn: "Result may be truncated; bump `--limit`."
+
+### 4. Filter
+
+Apply in order:
+
+1. `content.type == "Issue"` — skip DraftIssue and PullRequest.
+2. `$ME` is in `content.assignees` (array of login strings).
+3. **Default**: `status != "Done"`. Override only if `$ARGUMENTS` contains "include done", "all", or "done only" — and state the override in the scope line.
+4. Sprint filter from step 2 if `$ARGUMENTS` asked for it. `"no sprint"` → `sprint == null`.
+5. Free-form intent like "in review only" → `status == "In Review"` (match canonical Status values).
+
+### 5. Sort
+
+By status (Todo, In Progress, In Review, Blocked, Done), then by issue number ascending.
+
+### 6. Render
+
+Use the format below. If `$ARGUMENTS` was non-trivial, summarize the chosen interpretation in the scope line.
+
+## Output format
+
+```text
+## Issues assigned to @<login>
+Scope: <e.g. "open, current sprint (Sprint 43, 2026-04-27 → 2026-05-11)">
+
+| #   | Title                | Status      |
+| --- | -------------------- | ----------- |
+| [#1234](https://github.com/.../issues/1234) | Fix login redirect | In Progress |
+
+_N issues._
+```
+
+Rules:
+
+- Link the `#NUMBER` cell to `content.url`. Plain `#1234` if URL missing.
+- Escape `|` in titles as `\|`.
+- Zero matches → print scope line + `_No matching issues._` (no empty table).
+
+## Edge cases
+
+- `gh` unauthenticated / no project access → surface stderr verbatim, stop.
+- Custom field key mismatch (no `sprint` or `status` on items) → run `gh project field-list` and report which field name is unexpected.
+- Hardcoded org/project — do not accept overrides via `$ARGUMENTS`.

--- a/agent-skills/skills/list-issues/SKILL.md
+++ b/agent-skills/skills/list-issues/SKILL.md
@@ -3,81 +3,40 @@ name: list-issues
 description: Lists GitHub issues assigned to the current user from project informasjonsforvaltning/9, rendered as a Markdown table. Use when the user says "list my issues", "my issues", "issues assigned to me", "current sprint issues", or "previous sprint issues".
 model: sonnet
 argument-hint: [natural language filter, e.g. "current sprint" or "include done"]
-allowed-tools: Bash(gh project item-list:*), Bash(gh project field-list:*), Bash(gh api user:*), Bash(date:*), Bash(jq:*)
+allowed-tools: Bash(gh project item-list:*), Bash(gh api:*), Bash(date:*), Bash(jq:*)
 ---
-
-# List Issues
-
-List GitHub issues assigned to the current user from the project board, rendered as a Markdown table. Filter via `$ARGUMENTS` using natural language: "current sprint", "previous sprint", "include done", "in review only", etc.
 
 > **Scope**: hardcoded to org `informasjonsforvaltning`, project `9`. Edit this file to point at a different board.
 
 ## Steps
 
-### 1. Get the current user
+1. **Get the current user** — `gh api user --jq .login`. Save as `$ME`. On error, surface stderr verbatim and stop.
 
-```bash
-gh api user --jq .login
-```
+2. **Resolve sprint** (only if `$ARGUMENTS` mentions sprint or iteration). `gh project field-list --format json` does not return iteration config; use GraphQL:
+   ```bash
+   gh api graphql -f query='{ organization(login:"informasjonsforvaltning") { projectV2(number:9) { fields(first:50) { nodes { ... on ProjectV2IterationField { name configuration { iterations { title startDate duration } completedIterations { title startDate duration } } } } } } } }'
+   ```
+   Iteration entries have `{title, startDate, duration}`.
+   - **Current** = entry in `iterations` where `startDate <= today < startDate + duration days` (today via `date -u +%Y-%m-%d`).
+   - **Previous** = last entry of `completedIterations` (sorted by `startDate` desc).
+   - No current iteration matches → report "No active sprint on `<today>`" and stop unless `$ARGUMENTS` asked for previous.
 
-Save as `$ME`. If `gh` is not authenticated or returns an error, surface stderr verbatim and stop.
+3. **Fetch project items** — `gh project item-list 9 --owner informasjonsforvaltning --format json --limit 200`. Custom fields are flattened with lowercase, no-space keys: `status` (string, often emoji-prefixed like `"🏗 In progress"`), `sprint` (object with `title`, `startDate`, `duration`); unset fields are omitted. If `totalCount` exceeds returned `items` length, re-fetch with `--limit $totalCount` (rounded up to nearest 100). Do not proceed with truncated data.
 
-### 2. Resolve sprint (only if `$ARGUMENTS` mentions sprint or iteration)
+4. **Filter** in order:
+   1. `content.type == "Issue"` — skip DraftIssue and PullRequest.
+   2. `$ME` is in `assignees` (array of login strings).
+   3. **Default**: status does not contain `done` (case-insensitive substring, to tolerate emoji prefixes like `✅ Done`). Override only if `$ARGUMENTS` contains "include done", "all", or "done only" — and state the override in the scope line.
+   4. Sprint filter from step 2 if asked. `"no sprint"` → `sprint == null`.
+   5. Free-form intent like "in review only" → status contains `in review` (case-insensitive substring). Apply the same tolerant matching for any status filter.
 
-```bash
-gh project field-list 9 --owner informasjonsforvaltning --format json --limit 50
-```
-
-The Sprint field has shape:
-
-```json
-{
-  "name": "Sprint",
-  "type": "ProjectV2IterationField",
-  "configuration": {
-    "iterations":          [{ "title": "Sprint 43", "startDate": "2026-05-04", "duration": 14 }],
-    "completedIterations": [{ "title": "Sprint 42", "startDate": "2026-04-20", "duration": 14 }]
-  }
-}
-```
-
-- **Current** = entry in `iterations` where `startDate <= today < startDate + duration days` (today via `date -u +%Y-%m-%d`).
-- **Previous** = last entry of `completedIterations` (sorted by `startDate` desc).
-- If no current iteration matches (sprint gap), report "No active sprint on `<today>`" and stop unless `$ARGUMENTS` asked for previous.
-
-### 3. Fetch project items
-
-```bash
-gh project item-list 9 --owner informasjonsforvaltning --format json --limit 200
-```
-
-Custom fields are flattened with lowercase, no-space keys: `status` (string), `sprint` (object with `title`, `startDate`, `duration`). Unset fields are omitted from the item.
-
-If `totalCount` exceeds `--limit`, warn: "Result may be truncated; bump `--limit`."
-
-### 4. Filter
-
-Apply in order:
-
-1. `content.type == "Issue"` — skip DraftIssue and PullRequest.
-2. `$ME` is in `content.assignees` (array of login strings).
-3. **Default**: `status != "Done"`. Override only if `$ARGUMENTS` contains "include done", "all", or "done only" — and state the override in the scope line.
-4. Sprint filter from step 2 if `$ARGUMENTS` asked for it. `"no sprint"` → `sprint == null`.
-5. Free-form intent like "in review only" → `status == "In Review"` (match canonical Status values).
-
-### 5. Sort
-
-By status (Todo, In Progress, In Review, Blocked, Done), then by issue number ascending.
-
-### 6. Render
-
-Use the format below. If `$ARGUMENTS` was non-trivial, summarize the chosen interpretation in the scope line.
+5. **Sort** by status, then by issue number ascending. Status order (case-insensitive substring against the emoji-prefixed value): New, Todo, Ready, In Progress, In Review, Blocked, Done. Unknown statuses sort last.
 
 ## Output format
 
 ```text
 ## Issues assigned to @<login>
-Scope: <e.g. "open, current sprint (Sprint 43, 2026-04-27 → 2026-05-11)">
+Scope: <e.g. "open, current sprint (Uke 19, 2026-05-04 → 2026-05-10)">
 
 | #   | Title                | Status      |
 | --- | -------------------- | ----------- |
@@ -86,14 +45,11 @@ Scope: <e.g. "open, current sprint (Sprint 43, 2026-04-27 → 2026-05-11)">
 _N issues._
 ```
 
-Rules:
+## Rules
 
-- Link the `#NUMBER` cell to `content.url`. Plain `#1234` if URL missing.
+- Link `#NUMBER` to `content.url`. Plain `#1234` if URL missing.
 - Escape `|` in titles as `\|`.
 - Zero matches → print scope line + `_No matching issues._` (no empty table).
-
-## Edge cases
-
-- `gh` unauthenticated / no project access → surface stderr verbatim, stop.
+- If `$ARGUMENTS` was non-trivial, summarize the chosen interpretation in the scope line.
 - Custom field key mismatch (no `sprint` or `status` on items) → run `gh project field-list` and report which field name is unexpected.
 - Hardcoded org/project — do not accept overrides via `$ARGUMENTS`.


### PR DESCRIPTION
# Summary

- Add `/list-issues` skill to list GitHub project board issues assigned to the current user, with support for natural language filters (e.g. "current sprint", "in review only")
- Add `argument-hint` and `$ARGUMENTS` support to `create-bug-issue`, `create-feature-issue`, and `create-ux-issue` skills so they accept optional context
- Add explicit `gh pr create` rule to `create-pr` and `create-branch-and-pr` skills
- Document `/list-issues` in CLAUDE.md skills table