### PR TITLE
feat: detect issues a PR closes

### DIFF
--- a/agent-skills/skills/create-branch-and-pr/SKILL.md
+++ b/agent-skills/skills/create-branch-and-pr/SKILL.md
@@ -14,7 +14,14 @@ argument-hint: "[fixes #issue-number]"
 3. Create branch following the branch name template
 4. Stage all, commit following the commit message template. Commit message should be very short, max 50 characters
 5. Push branch
-6. Write a short pull request title and description, then ask for confirmation before creating the PR
+6. Determine which issues (if any) this PR closes:
+   - If `$ARGUMENTS` already names issues (e.g. `fixes #12`), use those.
+   - Otherwise list open issues with `gh issue list --state open --limit 50 --json number,title,labels`
+     and identify any the diff plausibly resolves (use `gh issue view <number>` to confirm scope).
+   - Present the candidate issue(s) and **ask the user to confirm** which, if any, this PR should
+     close. Never assume — if the user declines or none match, close nothing.
+7. Write a short pull request title and description, add a `Closes #<number>` line for each confirmed
+   issue, then ask for confirmation before creating the PR
 
 ### Rules
 
@@ -24,6 +31,8 @@ argument-hint: "[fixes #issue-number]"
 - Keep PR text short
 - Use bullet points for changes in the PR description
 - Never include a test plan
+- Always check whether the change closes an open issue; confirm candidates with the user before
+  adding them — never assume. Add each confirmed issue as a `Closes #<number>` line in the PR body.
 - Always ask for confirmation before creating the PR in GitHub
 - Do not create the PR until the user explicitly confirms
 - Use `gh pr create` to create the PR
@@ -46,8 +55,13 @@ Types: feat, fix, docs, style, refactor, test, chore
 ### PR description output format (exact)
 
 ```text
-# Summary $ARGUMENTS
+# Summary
 
 - ...
 - ...
+
+Closes #<number>
 ```
+
+Add one `Closes #<number>` line per confirmed issue. Omit the line entirely when the PR closes no
+issue.


### PR DESCRIPTION
# Summary

- create-branch-and-pr now checks whether the change closes an open issue
- Uses $ARGUMENTS if given (e.g. fixes #12), else lists open issues and matches the diff
- Asks the user to confirm candidates before closing — never assumes
- Adds a Closes #<number> line per confirmed issue to the PR body (replacing the old $ARGUMENTS-in-header form)