### PR TITLE
feat: bake true symlinks into skills:add

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,13 @@ Two steps:
 
 ```bash
 yarn install
-yarn skills:add        # pick "symlink" — keeps this repo as the single source of truth
+yarn skills:add        # installs the skills and symlinks them back to this repo
 ```
 
-> **Tip:** Choose the **symlink** option when prompted. That way, when someone improves a Skill in this repo, you get the update next time you run `git pull` — no reinstall needed.
+> **Tip:** `skills:add` installs each Skill into the shared agent store and then symlinks the store
+> back to this repo, so it stays the single source of truth. When someone improves a Skill, you get
+> it on your next `git pull` — no reinstall needed (open a new session to load the change). If you
+> ever need to re-establish the symlinks on their own, run `yarn skills:link`.
 
 #### Set your username (optional)
 

--- a/agent-skills/README.md
+++ b/agent-skills/README.md
@@ -54,9 +54,11 @@ argument-hint: [fixes #issue-number]
 2. Write `SKILL.md` with the frontmatter above
 3. Optionally add `scripts/<name>.sh` for Bash helpers
 4. `yarn skills:list` to confirm it's picked up
-5. `yarn skills:add` (pick symlink) and invoke `/my-new-skill` in Claude Code
+5. `yarn skills:add` to install it, then invoke `/my-new-skill` in Claude Code
 
-Symlinked skills pick up Markdown edits immediately — no rebuild, no restart.
+`yarn skills:add` installs skills into the shared agent store and then symlinks the store back to
+this repo, so Markdown edits (and `git pull`s) are picked up by the next session with no reinstall.
+(`yarn skills:link` runs that symlink step on its own, if you ever need to re-establish it.)
 
 ## Conventions
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "skills": "1.5.3"
   },
   "scripts": {
-    "skills:add": "skills add ./agent-skills/skills",
+    "skills:add": "skills add ./agent-skills/skills && node scripts/link-skills.mjs",
+    "skills:link": "node scripts/link-skills.mjs",
     "skills:list": "skills add ./agent-skills/skills --list",
     "skills:export": "node scripts/export-skills.mjs",
     "set-username": "bash scripts/set-username.sh"

--- a/scripts/link-skills.mjs
+++ b/scripts/link-skills.mjs
@@ -1,0 +1,91 @@
+// Make the installed skills track this repo via real symlinks, so edits and
+// `git pull` go live without re-running `yarn skills:add`.
+//
+// The `skills` CLI installs by *copying* each skill into a shared agent store
+// (~/.agents/skills/<name>) and symlinking every agent tool's dir
+// (~/.claude/skills/<name>, etc.) to that store. The copy is the part that goes
+// stale. This script replaces each store entry with a symlink into the repo, so
+// the existing agent-dir symlinks resolve straight through to the source.
+//
+// `yarn skills:add` runs this automatically as its final step, so a fresh install ends up linked
+// to the repo. Run `yarn skills:link` on its own to re-establish the symlinks at any time.
+
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import {
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
+
+const REPO_SKILLS = resolve("agent-skills/skills");
+const STORE = join(homedir(), ".agents", "skills");
+const CLAUDE = join(homedir(), ".claude", "skills");
+
+mkdirSync(STORE, { recursive: true });
+mkdirSync(CLAUDE, { recursive: true });
+
+// Point `linkPath` at `target` (absolute). Returns "ok" if already correct,
+// "linked" if newly created, "relinked" if an existing copy/link was replaced.
+function linkTo(target, linkPath) {
+  const want = resolve(target);
+  try {
+    const stat = lstatSync(linkPath);
+    if (
+      stat.isSymbolicLink() &&
+      resolve(dirname(linkPath), readlinkSync(linkPath)) === want
+    ) {
+      return "ok";
+    }
+    rmSync(linkPath, { recursive: true, force: true });
+    symlinkSync(want, linkPath, "dir");
+    return "relinked";
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      throw error;
+    }
+    symlinkSync(want, linkPath, "dir");
+    return "linked";
+  }
+}
+
+const counts = { ok: 0, linked: 0, relinked: 0, failed: 0 };
+
+for (const entry of readdirSync(REPO_SKILLS, { withFileTypes: true })) {
+  if (!entry.isDirectory()) {
+    continue;
+  }
+
+  const name = entry.name;
+  try {
+    // Store entry -> repo source; agent dir -> store entry (created if missing).
+    const store = linkTo(join(REPO_SKILLS, name), join(STORE, name));
+    const claude = linkTo(join(STORE, name), join(CLAUDE, name));
+    const status = [store, claude].includes("relinked")
+      ? "relinked"
+      : [store, claude].includes("linked")
+        ? "linked"
+        : "ok";
+    counts[status]++;
+    console.log(`${status.padEnd(8)} ${name}`);
+  } catch (error) {
+    counts.failed++;
+    console.error(`failed   ${name}: ${error.message}`);
+    if (error.code === "EPERM") {
+      console.error(
+        "  On Windows, enable Developer Mode or run elevated for symlink support.",
+      );
+    }
+  }
+}
+
+console.log(
+  `\n${counts.linked} linked, ${counts.relinked} relinked, ${counts.ok} already linked` +
+    (counts.failed ? `, ${counts.failed} failed` : "") +
+    ".",
+);
+console.log(`Skills now track ${REPO_SKILLS}.`);
+console.log("Open a new session to load changes; `git pull` is enough thereafter.");


### PR DESCRIPTION
# Summary

- Add scripts/link-skills.mjs + `yarn skills:link`: repoints the shared agent store (~/.agents/skills) at this repo via real symlinks, so the existing agent-dir links resolve straight to source
- Bake it into `yarn skills:add` (runs as the final step), so a fresh install ends up symlinked to the repo — git pull then updates skills with no reinstall
- Fix both READMEs: the old "pick symlink → single source of truth" promise was untrue (skills@1.5.3 copies source into the store); now accurate and one-command